### PR TITLE
Fix name of an image generated from a diagram

### DIFF
--- a/asciidocs/index.adoc
+++ b/asciidocs/index.adoc
@@ -355,7 +355,7 @@ image::lesen-von-beziehungen.jpeg[]
 *** Transport von Gütern
 *** ev. Statussymbol
 
-[plantuml,demo4,png]
+[plantuml,demo5,png]
 ----
 @startuml
 left to right direction


### PR DESCRIPTION
# Changes / Änderungen
This PR fixes the faulty naming of one image generated from a PlantUML diagram.
One index was used twice (=>diff), and therefore, the deployed GitHub Page displayed a wrong diagram.

Diese PR repariert den Namen eines generierten Bildes eines PlantUML Diagramms.
Ein Index wurde doppelt verwendet (siehe git diff), daher stellt die deployte GitHub Page ein falsches Diagramm dar.

## before / vorher
![image](https://user-images.githubusercontent.com/96107653/205095809-aeb29ad6-da90-4b3b-bdfe-dbfad388d0c2.png)

## after / danach
![after image](https://user-images.githubusercontent.com/96107653/205095691-923e4727-b197-4c8f-bc33-c067c8f1f16b.png)